### PR TITLE
'moving_average' fixes

### DIFF
--- a/queue/moving_average.py
+++ b/queue/moving_average.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from collections import deque
+
 
 class MovingAverage(object):
     def __init__(self, size):
@@ -5,8 +8,7 @@ class MovingAverage(object):
         Initialize your data structure here.
         :type size: int
         """
-        self.size = size
-        self.queue = collections.deque()
+        self.queue = deque(maxlen=size)
 
     def next(self, val):
         """
@@ -14,19 +16,14 @@ class MovingAverage(object):
         :rtype: float
         """
         self.queue.append(val)
-        if len(self.queue) > self.size:
-            self.queue.popleft()
-        sum = float(0)
-        for num in self.queue:
-            sum += num
-        return sum / len(self.queue)
+        return sum(self.queue) / len(self.queue)
+
 
 # Given a stream of integers and a window size,
 # calculate the moving average of all integers in the sliding window.
-
-# For example,
-m = MovingAverage(3);
-m.next(1) = 1
-m.next(10) = (1 + 10) / 2
-m.next(3) = (1 + 10 + 3) / 3
-m.next(5) = (10 + 3 + 5) / 3
+if __name__ == '__main__':
+    m = MovingAverage(3)
+    assert m.next(1) == 1
+    assert m.next(10) == (1 + 10) / 2
+    assert m.next(3) == (1 + 10 + 3) / 3
+    assert m.next(5) == (10 + 3 + 5) / 3


### PR DESCRIPTION
* Imported `__future__.division` (to ensure true division is used whether using Python 2 or 3)
* Imported `collections.deque` (previously missing)
* Used the `maxlen` argument for `deque` (instead of checking `len(self.queue) > self.size`)
* `sum` shouldn't be used as a variable name (since it shadows the builtin function name)
* Added `if __name__ == '__main__'` (to ensure tests are not run if the file is imported)
* Fixed the tests so they wouldn't raise `SyntaxError`'s
