### PR TITLE
Fix LinkedListQueue dequeue method

### DIFF
--- a/queue/queue.py
+++ b/queue/queue.py
@@ -88,8 +88,9 @@ class LinkedListQueue(AbstractQueue):
         if not self.front:
             self.front = node
             self.rear = node
-        node.next = self.rear
-        self.rear = node
+        else:
+            self.rear.next = node
+            self.rear = node
         self.top += 1
 
     def dequeue(self):
@@ -98,7 +99,9 @@ class LinkedListQueue(AbstractQueue):
         value = self.front.value
         if self.front is self.rear:
             self.front = None
-        self.front = self.front.next
+            self.rear = None
+        else:
+            self.front = self.front.next
         self.top -= 1
         return value
 


### PR DESCRIPTION
When LinkedListQueue have one item (self.front == self.rear)
Dequeue method call makes below error.
AttributeError: 'NoneType' object has no attribute 'next'