### PR TITLE
update count_ones.py

### DIFF
--- a/bit/count_ones.py
+++ b/bit/count_ones.py
@@ -8,18 +8,18 @@ representation 00000000000000000000000000001011,
 so the function should return 3.
 
 T(n)- O(log n)
-"""
-
+Number of loops is
+equal to the number of 1s in the binary representation."""
 
 def count_ones(n):
-    """
-    :type n: int
-    :rtype: int
-    """
-    if n < 0:
-        return
-    counter = 0
+    """Using Brian Kernighan’s Algorithm. (Recursive Approach)"""
+    if not n: return 0
+    return 1 + count_ones(n & (n-1))
+
+def countSetBits(n):
+    """Using Brian Kernighan’s Algorithm. (Iterative Approach)"""
+    count = 0
     while n:
-        counter += n & 1
-        n >>= 1
-    return counter
+        n &= (n-1) 
+        count += 1
+    return count

--- a/bit/count_ones.py
+++ b/bit/count_ones.py
@@ -6,8 +6,12 @@ returns the number of ’1' bits it has
 For example, the 32-bit integer ’11' has binary
 representation 00000000000000000000000000001011,
 so the function should return 3.
+ 
+T(n)- O(k)   : k is the number of 1s present in binary representation.
+NOTE: this complexity is better than O(log n). 
+e.g. for n = 00010100000000000000000000000000
+only 2 iterations are required.
 
-T(n)- O(log n)
 Number of loops is
 equal to the number of 1s in the binary representation."""
 
@@ -16,7 +20,7 @@ def count_ones(n):
     if not n: return 0
     return 1 + count_ones(n & (n-1))
 
-def countSetBits(n):
+def count_ones(n):
     """Using Brian Kernighan’s Algorithm. (Iterative Approach)"""
     count = 0
     while n:


### PR DESCRIPTION
Complexity is better than the previous approach since number of loops is
   equal to the number of 1s in the binary representation.
Also (n < 0) check is not needed since it is specified unsigned integer.