### PR TITLE
fixed peek() method of the ArrayStack

### DIFF
--- a/stack/stack.py
+++ b/stack/stack.py
@@ -53,9 +53,12 @@ class ArrayStack(AbstractStack):
         return value
 
     def peek(self):
+        """
+            returns the current top element of the stack.
+        """
         if self.isEmpty():
             raise IndexError("stack is empty")
-        return self.array[self.top]
+        return self.array[self.top -1]
 
     def expand(self):
         """


### PR DESCRIPTION
I fixed the method:  
```python
def peek(self):
```
from the class ArrayStack. Now the method returns the current top element of the stack.  