### PR TITLE
Modify the flake8 option in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,7 @@ install:
     - pip install -r requirements.txt
     - pip install flake8  # pytest  # add another testing frameworks later
 before_script:
-    # stop the build if there are Python syntax errors or undefined names
-    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
-    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - flake8 --show-source .
 script:
     - pytest
 notifications:


### PR DESCRIPTION
`--max-line-length=<n>` option Set the maximum length that any line (with some exceptions) may be.
Exceptions include lines that are either strings or comments which are entirely URLs. 
The standard style coding max line length is 79.
We do not need to count number of errors too. We just need to know where exact error from the source. So I remove these option by `flake8 --show-source .`
You can refer the flake8 here:  http://flake8.pycqa.org/en/latest/user/options.html#