### PR TITLE
Fixes #256 change strip_url_params3 to stop flaky unit test failures

### DIFF
--- a/algorithms/strings/strip_url_params.py
+++ b/algorithms/strings/strip_url_params.py
@@ -10,6 +10,8 @@ from collections import defaultdict
 import urllib
 import urllib.parse
 
+from collections import OrderedDict
+
 # Here is a very non-pythonic grotesque solution
 def strip_url_params1(url, params_to_strip=None):
     
@@ -37,7 +39,7 @@ def strip_url_params1(url, params_to_strip=None):
                     string = ''
                 else:
                     string += char
-            dict = defaultdict(int)
+            dict = OrderedDict()
             # logic for checking whether we should add the string to our result
             for i in key_value_string:
                 _token = i.split('=')

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -339,23 +339,23 @@ class TestRomanToInt(unittest.TestCase):
         self.assertEqual(3999, roman_to_int("MMMCMXCIX"))
 
 
-# class TestStripUrlParams(unittest.TestCase):
-#     """[summary]
-#     Test for the file strip_urls_params.py
+class TestStripUrlParams(unittest.TestCase):
+    """[summary]
+    Test for the file strip_urls_params.py
 
-#     Arguments:
-#         unittest {[type]} -- [description]
-#     """
+    Arguments:
+        unittest {[type]} -- [description]
+    """
 
-#     def test_strip_url_params1(self):
-#         self.assertEqual(strip_url_params1("www.saadbenn.com?a=1&b=2&a=2"), "www.saadbenn.com?a=1&b=2")
-#         self.assertEqual(strip_url_params1("www.saadbenn.com?a=1&b=2", ['b']), "www.saadbenn.com?a=1")
-#     def test_strip_url_params2(self):
-#         self.assertEqual(strip_url_params2("www.saadbenn.com?a=1&b=2&a=2"), "www.saadbenn.com?a=1&b=2")
-#         self.assertEqual(strip_url_params2("www.saadbenn.com?a=1&b=2", ['b']), "www.saadbenn.com?a=1")
-#     def test_strip_url_params3(self):
-#         self.assertEqual(strip_url_params3("www.saadbenn.com?a=1&b=2&a=2"), "www.saadbenn.com?a=1&b=2")
-#         self.assertEqual(strip_url_params3("www.saadbenn.com?a=1&b=2", ['b']), "www.saadbenn.com?a=1")
+    def test_strip_url_params1(self):
+        self.assertEqual(strip_url_params1("www.saadbenn.com?a=1&b=2&a=2"), "www.saadbenn.com?a=1&b=2")
+        self.assertEqual(strip_url_params1("www.saadbenn.com?a=1&b=2", ['b']), "www.saadbenn.com?a=1")
+    def test_strip_url_params2(self):
+        self.assertEqual(strip_url_params2("www.saadbenn.com?a=1&b=2&a=2"), "www.saadbenn.com?a=1&b=2")
+        self.assertEqual(strip_url_params2("www.saadbenn.com?a=1&b=2", ['b']), "www.saadbenn.com?a=1")
+    def test_strip_url_params3(self):
+        self.assertEqual(strip_url_params3("www.saadbenn.com?a=1&b=2&a=2"), "www.saadbenn.com?a=1&b=2")
+        self.assertEqual(strip_url_params3("www.saadbenn.com?a=1&b=2", ['b']), "www.saadbenn.com?a=1")
 
 
 class TestValidateCoordinates(unittest.TestCase):


### PR DESCRIPTION
Use OrderedDict to preserve query string key order. This should prevent `?a=1&b=2` returning          
 `?b=2&a=1` sometimes and failing the test even though it's semantically correct.

- [x ] **if done some changes :**
  - [x ] wrote short description in the PR explaining what the changes do ?
  - [ x] Fixes #[issue number] if related to any issue
