### PR TITLE
Add two more breaking bad tests

### DIFF
--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -80,6 +80,12 @@ class TestBreakingBad(unittest.TestCase):
     def test_bracket(self):
         self.assertEqual(('[Am]azon', 'Mi[cro]soft', 'Goog[le]'), bracket(self.words, self.symbols))
 
+    def test_no_match(self):
+        self.assertEqual(('Amazon', 'Microsoft', 'Google'), bracket(self.words, ['thisshouldnotmatch']))
+
+    def test_duplicate_symbols(self):
+        self.assertEqual(('Amazon', 'M[i]crosoft', 'Google'), bracket(self.words, ['i', 'i']))
+
 
 class TestDecodeString(unittest.TestCase):
     """[summary]

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -79,13 +79,8 @@ class TestBreakingBad(unittest.TestCase):
 
     def test_bracket(self):
         self.assertEqual(('[Am]azon', 'Mi[cro]soft', 'Goog[le]'), bracket(self.words, self.symbols))
-
-    def test_no_match(self):
         self.assertEqual(('Amazon', 'Microsoft', 'Google'), bracket(self.words, ['thisshouldnotmatch']))
-
-    def test_duplicate_symbols(self):
         self.assertEqual(('Amazon', 'M[i]crosoft', 'Google'), bracket(self.words, ['i', 'i']))
-
 
 class TestDecodeString(unittest.TestCase):
     """[summary]


### PR DESCRIPTION
Add two more tests to `bracket(words, symbols)` function in `strings/breaking_bad.py`. Adding these tests results in 100% branch coverage for the function. 

- Test 1: Test to match symbols that do not exist in the word list. This should return the words without any changes made to them.

- Test 2: Try to match two duplicate symbols. It should only encapsulate the match once ([i]), not twice ([[i]]).
