### PR TITLE
Add tests to test_linkedlist to increase coverage for is_palindrome_dict

### DIFF
--- a/tests/test_linkedlist.py
+++ b/tests/test_linkedlist.py
@@ -9,7 +9,8 @@ from algorithms.linkedlist import (
     is_cyclic,
     merge_two_list, merge_two_list_recur,
     is_palindrome, is_palindrome_stack, is_palindrome_dict,
-    RandomListNode, copy_random_pointer_v1, copy_random_pointer_v2
+    RandomListNode, copy_random_pointer_v1, copy_random_pointer_v2,
+    intersection
 )
 
 
@@ -32,17 +33,27 @@ def convert(head):
 
 class TestSuite(unittest.TestCase):
     def setUp(self):
-        # list test for palindrome
+        # Valid list test for palindrome
         self.l = Node('A')
         self.l.next = Node('B')
         self.l.next.next = Node('C')
         self.l.next.next.next = Node('B')
         self.l.next.next.next.next = Node('A')
-
+        # Invalid list test for palindrome with even number of nodes
         self.l1 = Node('A')
         self.l1.next = Node('B')
         self.l1.next.next = Node('C')
         self.l1.next.next.next = Node('B')
+        # Invalid list test for palindrome with odd number of nodes
+        self.l2 = Node('A')
+        self.l2.next = Node('B')
+        self.l2.next.next = Node('C')
+        self.l2.next.next.next = Node('D')
+        self.l2.next.next.next.next = Node('A')
+        # Valid list test for palindrome with one single node
+        self.l3 = Node('A')
+
+
 
     def test_reverse_list(self):
         head = Node(1)
@@ -174,6 +185,9 @@ class TestSuite(unittest.TestCase):
     def test_is_palindrome_dict(self):
         self.assertTrue(is_palindrome_dict(self.l))
         self.assertFalse(is_palindrome_dict(self.l1))
+        self.assertFalse(is_palindrome_dict(self.l2))
+        self.assertFalse(is_palindrome_dict(self.l3))
+        self.assertTrue(is_palindrome_dict(None))
 
     def test_solution_0(self):
         self._init_random_list_nodes()
@@ -209,6 +223,72 @@ class TestSuite(unittest.TestCase):
         random_list_node3.next, random_list_node3.random = random_list_node4, random_list_node2
         random_list_node4.next = random_list_node5
         random_list_node5.random = random_list_node3
+
+    def test_intersection(self):
+        # create linked list as:
+        # 1 -> 3 -> 5
+        #            \
+        #             7 -> 9 -> 11
+        #            /
+        # 2 -> 4 -> 6
+        a1 = Node(1)
+        b1 = Node(3)
+        c1 = Node(5)
+        d = Node(7)
+        a2 = Node(2)
+        b2 = Node(4)
+        c2 = Node(6)
+        e = Node(9)
+        f = Node(11)
+
+        a1.next = b1
+        b1.next = c1
+        c1.next = d
+        a2.next = b2
+        b2.next = c2
+        c2.next = d
+        d.next = e
+        e.next = f
+
+        self.assertEqual(7, intersection.intersection(a1, a2).val)
+
+    def test_intersection_no_merge(self):
+        # create linked list as:
+        # 1 -> 3 -> 5
+        # 2 -> 4 -> 6
+        a1 = Node(1)
+        b1 = Node(3)
+        c1 = Node(5)
+        a2 = Node(2)
+        b2 = Node(4)
+        c2 = Node(6)
+
+        a1.next = b1
+        b1.next = c1
+        a2.next = b2
+        b2.next = c2
+
+        self.assertEqual(None, intersection.intersection(a1, a2))
+
+    def test_intersection_one_longer(self):
+        # create linked list as:
+        # 1 -> 3 -> 5
+        # 2 -> 4 -> 6
+        pre_a1 = Node(0)
+        a1 = Node(1)
+        b1 = Node(3)
+        c1 = Node(5)
+        a2 = Node(2)
+        b2 = Node(4)
+        c2 = Node(6)
+
+        pre_a1.next = a1
+        a1.next = b1
+        b1.next = c1
+        a2.next = b2
+        b2.next = c2
+
+        self.assertEqual(None, intersection.intersection(pre_a1, a2))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add three more assertions with corresponding lists in setUp() to test the function is_palindrome_dict in linkedlist/is_palindrome.py. Adding these test cases increases the branch coverage for the function from 77% to 100%.

**List of added test cases:**
1. A linked list consisting of an odd number of nodes and is _not_ a valid palindrome. This assertion expects the function to return False.

2. A linked list consisting of _only one_ node. This assertion expects the function to return True.

3. A case when there is no "head" at all and the input is _None_. This assertion expects the function to return True. 