### PR TITLE
Fix gcd

### DIFF
--- a/algorithms/maths/gcd.py
+++ b/algorithms/maths/gcd.py
@@ -1,7 +1,19 @@
 def gcd(a, b):
     """Computes the greatest common divisor of integers a and b using
     Euclid's Algorithm.
+    gcd{𝑎,𝑏}=gcd{−𝑎,𝑏}=gcd{𝑎,−𝑏}=gcd{−𝑎,−𝑏}
+    See proof: https://proofwiki.org/wiki/GCD_for_Negative_Integers
     """
+    a_int = isinstance(a, int)
+    b_int = isinstance(b, int)
+    a = abs(a)
+    b = abs(b)
+    if not(a_int or b_int):
+        raise ValueError("Input arguments are not integers")
+
+    if (a == 0) or (b == 0) :
+        raise ValueError("One or more input arguments equals zero")
+
     while b != 0:
         a, b = b, a % b
     return a
@@ -9,7 +21,7 @@ def gcd(a, b):
 
 def lcm(a, b):
     """Computes the lowest common multiple of integers a and b."""
-    return a * b / gcd(a, b)
+    return abs(a) * abs(b) / gcd(a, b)
 
 
 """

--- a/tests/test_maths.py
+++ b/tests/test_maths.py
@@ -29,6 +29,7 @@ from algorithms.maths import (
 )
 
 import unittest
+import pytest
 
 
 class TestPower(unittest.TestCase):
@@ -128,8 +129,37 @@ class TestGcd(unittest.TestCase):
         self.assertEqual(4, gcd(8, 12))
         self.assertEqual(1, gcd(13, 17))
 
+    def test_gcd_non_integer_input(self):
+        with pytest.raises(ValueError, match=r"Input arguments are not integers"):
+            gcd(1.0, 5)
+            gcd(5, 6.7)
+            gcd(33.8649, 6.12312312)
+
+    def test_gcd_zero_input(self):
+        with pytest.raises(ValueError, match=r"One or more input arguments equals zero"):
+            gcd(0, 12)
+            gcd(12, 0)
+            gcd(0, 0)
+
+    def test_gcd_negative_input(self):
+        self.assertEqual(1, gcd(-13, -17))
+        self.assertEqual(4, gcd(-8, 12))
+        self.assertEqual(8, gcd(24, -16))
+
     def test_lcm(self):
         self.assertEqual(24, lcm(8, 12))
+        self.assertEqual(5767, lcm(73, 79))
+
+    def test_lcm_negative_numbers(self):
+        self.assertEqual(24, lcm(-8, -12))
+        self.assertEqual(5767, lcm(73, -79))
+        self.assertEqual(1, lcm(-1, 1))
+
+    def test_lcm_zero_input(self):
+        with pytest.raises(ValueError, match=r"One or more input arguments equals zero"):
+            lcm(0, 12)
+            lcm(12, 0)
+            lcm(0, 0)
 
     def test_trailing_zero(self):
         self.assertEqual(1, trailing_zero(34))
@@ -138,6 +168,7 @@ class TestGcd(unittest.TestCase):
     def test_gcd_bit(self):
         self.assertEqual(4, gcd_bit(8, 12))
         self.assertEqual(1, gcd(13, 17))
+
 
 
 class TestGenerateStroboGrammatic(unittest.TestCase):


### PR DESCRIPTION
Fixing the gcd.py module. Checking the input arguments for the gcd function for the following cases: 

- One or more arguments equals zero

- One or more arguments are not of integer type

The lcm and gcd function can now handle negative numbers as inputs. Additional tests were added to test the new fixes.

See also following links for more information:
[Negative integers for GCD]( https://proofwiki.org/wiki/GCD_for_Negative_Integers )
[Negative integers for LCM](https://math.stackexchange.com/questions/541643/how-to-find-the-lcm-of-one-negative-and-one-positive-integer)
