### PR TITLE
fix_rotate.py

### DIFF
--- a/algorithms/strings/rotate.py
+++ b/algorithms/strings/rotate.py
@@ -7,12 +7,13 @@ rotate("hello", 5) return "hello"
 rotate("hello", 6) return "elloh"
 rotate("hello", 7) return "llohe"
 
-accepts two strings
-returns bool
+
 """
 def rotate(s, k):
-    double_s = s + s
+    long_string = s
+    while k >= len(long_string):
+        long_string += s
     if k <= len(s):
-        return double_s[k:k + len(s)]
+        return long_string[k:k + len(s)]
     else:
-        return double_s[k-len(s):k]
+        return long_string[k-len(s):k]


### PR DESCRIPTION
The way it was, you couldn't pass in a rotation higher than the length of the string doubled without getting a blank string in return. This way allows you to pass in any positive integer and get a result.

Also,
The last line of the description said that it took 2 strings and returned a boolean. This is not correct. The first line of the comment is correct.