### PR TITLE
Add UnionFind data structure with a Rust backend.

### DIFF
--- a/algorithms/arrays/limit.py
+++ b/algorithms/arrays/limit.py
@@ -14,4 +14,12 @@ Complexity = O(n)
 
 # tl:dr -- array slicing by value
 def limit(arr, min_lim=None, max_lim=None):
+    if len(arr) == 0:
+        return arr
+
+    if min_lim is None:
+        min_lim = min(arr)
+    if max_lim is None:
+        max_lim = max(arr)
+
     return list(filter(lambda x: (min_lim <= x <= max_lim), arr))

--- a/algorithms/unionfind/__init__.py
+++ b/algorithms/unionfind/__init__.py
@@ -1,0 +1,3 @@
+import pyreunion
+
+UnionFind = pyreunion.UnionFind

--- a/algorithms/unionfind/count_islands.py
+++ b/algorithms/unionfind/count_islands.py
@@ -36,43 +36,18 @@ Operation #4: addLand(2, 1) turns the water at grid[2][1] into a land.
 0 1 0
 """
 
+from . import UnionFind
+
 
 class Solution(object):
     def num_islands2(self, m, n, positions):
         ans = []
-        islands = Union()
+        islands = UnionFind()
         for p in map(tuple, positions):
-            islands.add(p)
             for dp in (0, 1), (0, -1), (1, 0), (-1, 0):
                 q = (p[0] + dp[0], p[1] + dp[1])
                 if q in islands.id:
                     islands.unite(p, q)
-            ans += [islands.count]
+            ans += [len(islands.subsets())]
         return ans
 
-class Union(object):
-    def __init__(self):
-        self.id = {}
-        self.sz = {}
-        self.count = 0
-
-    def add(self, p):
-        self.id[p] = p
-        self.sz[p] = 1
-        self.count += 1
-
-    def root(self, i):
-        while i != self.id[i]:
-            self.id[i] = self.id[self.id[i]]
-            i = self.id[i]
-        return i
-
-    def unite(self, p, q):
-        i, j = self.root(p), self.root(q)
-        if i == j:
-            return
-        if self.sz[i] > self.sz[j]:
-            i, j = j, i
-        self.id[i] = j
-        self.sz[j] += self.sz[i]
-        self.count -= 1

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,9 @@ setup(name='algorithms',
       author_email="kwk236@gmail.com",
       license='MIT',
       packages=find_packages(exclude=('tests', 'tests.*')),
+      install_requires=[
+          'pyreunion>=0.1.3, < 0.2'
+      ],
       classifiers=[
           'Programming Language :: Python :: 3',
           'Programming Language :: Python :: 3.4',


### PR DESCRIPTION
Feature:

- A fast implementation of the UnionFind data structure that has a [Rust backend](https://docs.rs/reunion/0.1.14/reunion/).

Minor updates:

- Refactor the Solution class in `algorithms/unionfind/count_islands.py` to use the new UnionFind API.

Bug Fixes:

- Add None checks at the boundaries for Array limit (so that the tests pass).