### PR TITLE
Fix remove_duplicates function to handle binary values

### DIFF
--- a/algorithms/arrays/remove_duplicates.py
+++ b/algorithms/arrays/remove_duplicates.py
@@ -10,6 +10,18 @@ Output: [1, 2, 3, 4, 'hey', 'hello', True, False]
 
 
 def remove_duplicates(array):
+    """Removes duplicates from the input array while preserving the order of the first occurrence of each distinct item.
+
+    Args:
+        array (list): The input array containing elements with potential duplicates.
+
+    Returns:
+        list: A new array with duplicates removed, maintaining the order of the first occurrence of each item.
+
+    Examples:
+        >>> remove_duplicates([1, 1, 1, 2, 2, 3, 4, 4, "hey", "hey", "hello", True, True, False])
+        [1, 2, 3, 4, 'hey', 'hello', True, False]
+    """
     new_array = []  # Preserve order of first distinct item
     seen = set()  # Track the unique items
 

--- a/algorithms/arrays/remove_duplicates.py
+++ b/algorithms/arrays/remove_duplicates.py
@@ -4,15 +4,18 @@ removed.
 
 For example:
 
-Input: [1, 1 ,1 ,2 ,2 ,3 ,4 ,4 ,"hey", "hey", "hello", True, True]
-Output: [1, 2, 3, 4, 'hey', 'hello']
+Input: [1, 1 ,1 ,2 ,2 ,3 ,4 ,4 ,"hey", "hey", "hello", True, True, False]
+Output: [1, 2, 3, 4, 'hey', 'hello', True, False]
 """
 
+
 def remove_duplicates(array):
-    new_array = []
+    new_array = []  # Preserve order of first distinct item
+    seen = set()  # Track the unique items
 
     for item in array:
-        if item not in new_array:
+        if all([item is not elem for elem in seen]):
             new_array.append(item)
+            seen.add(item)
 
     return new_array

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -9,7 +9,7 @@ from algorithms.arrays import (
     missing_ranges,
     move_zeros,
     plus_one_v1, plus_one_v2, plus_one_v3,
-    remove_duplicates
+    remove_duplicates,
     rotate_v1, rotate_v2, rotate_v3,
     summarize_ranges,
     three_sum,
@@ -299,14 +299,21 @@ class TestPlusOne(unittest.TestCase):
         self.assertListEqual(plus_one_v3([9, 9, 9, 9]),
                              [1, 0, 0, 0, 0])
 
-class TestRemoveDuplicate(unittest.TestCase):
 
+class TestRemoveDuplicate(unittest.TestCase):
     def test_remove_duplicates(self):
-        self.assertListEqual(remove_duplicates([1,1,1,2,2,2,3,3,4,4,5,6,7,7,7,8,8,9,10,10]))
-        self.assertListEqual(remove_duplicates(["hey", "hello", "hello", "car", "house", "house"]))
-        self.assertListEqual(remove_duplicates([True, True, False, True, False, None, None]))
-        self.assertListEqual(remove_duplicates([1,1,"hello", "hello", True, False, False]))
-        self.assertListEqual(remove_duplicates([1, "hello", True, False]))
+        self.assertListEqual(remove_duplicates([1, 1, 1, 2, 2, 2, 3, 3, 4, 4, 5, 6, 7, 7, 7, 8, 8, 9, 10, 10]),
+                             [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        self.assertListEqual(remove_duplicates(["hey", "hello", "hello", "car", "house", "house"]),
+                             ["hey", "hello", "car", "house"])
+        self.assertListEqual(remove_duplicates([True, True, False, True, False, None, None]),
+                             [True, False, None])
+        self.assertListEqual(remove_duplicates([1, 1, "hello", "hello", True, False, False]),
+                             [1, "hello", True, False])
+        self.assertListEqual(remove_duplicates([1, "hello", True, False]),
+                             [1, "hello", True, False])
+        self.assertListEqual(remove_duplicates([False, True, False, True]),
+                             [False, True])
 
 
 class TestRotateArray(unittest.TestCase):


### PR DESCRIPTION
This PR addresses an issue (originally found in unit test run) where the binary values for `1` and `True` (`0` and `False`) are treated equally for this function.

## Changes
- Updated implementation of `remove_duplicates(array)` function.
- Updated the unit tests for `remove_duplicates(array)` function.
- Added docstring to reflect the improved behavior and provide clear examples.