### PR TITLE
Fixed minor bugs from unix.path

### DIFF
--- a/algorithms/unix/path/simplify_path.py
+++ b/algorithms/unix/path/simplify_path.py
@@ -14,10 +14,12 @@ In this case, you should ignore redundant slashes and return "/home/foo".
 
 Reference: https://leetcode.com/problems/simplify-path/description/
 """
+import posixpath
 
-import os
+
 def simplify_path_v1(path):
-    return os.path.abspath(path)
+    return posixpath.normpath(path)
+
 
 def simplify_path_v2(path):
     stack, tokens = [], path.split("/")

--- a/tests/test_unix.py
+++ b/tests/test_unix.py
@@ -22,11 +22,11 @@ class TestUnixPath(unittest.TestCase):
     def test_full_path(self):
         file_name = "file_name"
         # Test full path relative
-        expect_path = "{}/{}".format(os.getcwd(), file_name)
+        expect_path = os.path.join('{}', '{}').format(os.getcwd(), file_name)
         self.assertEqual(expect_path, full_path(file_name))
         # Test full path with expanding user
         # ~/file_name
-        expect_path = "{}/{}".format(os.path.expanduser('~'), file_name)
+        expect_path = os.path.join('{}', '{}').format(os.path.expanduser('~'), file_name)
         self.assertEqual(expect_path, full_path("~/{}".format(file_name)))
 
     def test_split(self):


### PR DESCRIPTION
Resolves minor bug seen from `tests/test_unix.py` under `TestUnixPath`.

The original implementation uses `"{}/{}"` which causes the bug when tested under Windows OS. I generalized it with:
```python
os.path.join('{}', '{}')
```
without assuming the local machine's OS.

## Changes
- Fixed error from `TestUnixPath.test_full_path` method with `os.path.join('{}', '{}')`.
- Fixed `unix.path.simplify_path.simplify_path_v1()` function with `posixpath.normpath()` function.