### PR TITLE
Add first cyclic node detection in linked list

### DIFF
--- a/algorithms/linkedlist/first_cyclic_node.c
+++ b/algorithms/linkedlist/first_cyclic_node.c
@@ -1,0 +1,64 @@
+"""
+    Given a linked list, find the first node of a cycle in it.
+    1 -> 2 -> 3 -> 4 -> 5 -> 1  => 1
+    A -> B -> C -> D -> E -> C  => C
+
+    Note: The solution is a direct implementation
+          Floyd's cycle-finding algorithm (Floyd's Tortoise and Hare).
+"""
+import unittest
+
+
+class Node:
+
+    def __init__(self, x):
+        self.val = x
+        self.next = None
+
+
+def first_cyclic_node(head):
+    """
+    :type head: Node
+    :rtype: Node
+    """
+    runner = walker = head
+    while runner and runner.next:
+        runner = runner.next.next
+        walker = walker.next
+        if runner is walker:
+            break
+
+    if runner is None or runner.next is None:
+        return None
+
+    walker = head
+    while runner is not walker:
+        runner, walker = runner.next, walker.next
+    return runner
+
+
+class TestSuite(unittest.TestCase):
+
+    def test_first_cyclic_node(self):
+
+        # create linked list => A -> B -> C -> D -> E -> C
+        head = Node('A')
+        head.next = Node('B')
+        curr = head.next
+
+        cyclic_node = Node('C')
+        curr.next = cyclic_node
+
+        curr = curr.next
+        curr.next = Node('D')
+        curr = curr.next
+        curr.next = Node('E')
+        curr = curr.next
+        curr.next = cyclic_node
+
+        self.assertEqual('C', first_cyclic_node(head).val)
+
+
+if __name__ == '__main__':
+
+    unittest.main()


### PR DESCRIPTION
Implement Floyd's cycle-finding algorithm to detect the first cyclic node in a linked list. Includes a test suite for validation.