### PR TITLE
Fix security issues: remove eval(), use secrets for crypto, pin CI actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,10 +8,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.13"
 
@@ -22,7 +22,7 @@ jobs:
         run: python -m build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4
         with:
           name: dist
           path: dist/
@@ -35,10 +35,10 @@ jobs:
       id-token: write
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4
         with:
           name: dist
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdb2  # release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,4 +41,4 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdb2  # release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # release/v1

--- a/algorithms/linked_list/kth_to_last.py
+++ b/algorithms/linked_list/kth_to_last.py
@@ -21,7 +21,7 @@ class Node:
 
 
 def kth_to_last_eval(head: Node, k: int) -> Node | bool:
-    """Find the kth to last element using eval (not safe for user input).
+    """Find the kth to last element using a safe iterative loop.
 
     Args:
         head: Head of the linked list.
@@ -38,14 +38,15 @@ def kth_to_last_eval(head: Node, k: int) -> Node | bool:
     if not isinstance(k, int) or not head.val:
         return False
 
-    nexts = ".".join(["next" for _ in range(1, k + 1)])
-    seeker = ".".join(["head", nexts])
-
     while head:
-        if eval(seeker) is None:  # noqa: S307
+        seeker = head
+        for _ in range(k):
+            if seeker is None:
+                return False
+            seeker = seeker.next
+        if seeker is None:
             return head
-        else:
-            head = head.next
+        head = head.next
 
     return False
 

--- a/algorithms/math/diffie_hellman_key_exchange.py
+++ b/algorithms/math/diffie_hellman_key_exchange.py
@@ -15,7 +15,7 @@ Complexity:
 from __future__ import annotations
 
 import math
-from random import randint
+import secrets
 
 
 def _prime_check(num: int) -> bool:
@@ -112,7 +112,7 @@ def alice_private_key(p: int) -> int:
     Returns:
         A random private key.
     """
-    return randint(1, p - 1)
+    return secrets.randbelow(p - 1) + 1
 
 
 def alice_public_key(a_pr_k: int, a: int, p: int) -> int:
@@ -126,7 +126,7 @@ def alice_public_key(a_pr_k: int, a: int, p: int) -> int:
     Returns:
         Alice's public key.
     """
-    return pow(a, a_pr_k) % p
+    return pow(a, a_pr_k, p)
 
 
 def bob_private_key(p: int) -> int:
@@ -138,7 +138,7 @@ def bob_private_key(p: int) -> int:
     Returns:
         A random private key.
     """
-    return randint(1, p - 1)
+    return secrets.randbelow(p - 1) + 1
 
 
 def bob_public_key(b_pr_k: int, a: int, p: int) -> int:
@@ -152,7 +152,7 @@ def bob_public_key(b_pr_k: int, a: int, p: int) -> int:
     Returns:
         Bob's public key.
     """
-    return pow(a, b_pr_k) % p
+    return pow(a, b_pr_k, p)
 
 
 def alice_shared_key(b_pu_k: int, a_pr_k: int, p: int) -> int:
@@ -166,7 +166,7 @@ def alice_shared_key(b_pu_k: int, a_pr_k: int, p: int) -> int:
     Returns:
         The shared secret key.
     """
-    return pow(b_pu_k, a_pr_k) % p
+    return pow(b_pu_k, a_pr_k, p)
 
 
 def bob_shared_key(a_pu_k: int, b_pr_k: int, p: int) -> int:
@@ -180,7 +180,7 @@ def bob_shared_key(a_pu_k: int, b_pr_k: int, p: int) -> int:
     Returns:
         The shared secret key.
     """
-    return pow(a_pu_k, b_pr_k) % p
+    return pow(a_pu_k, b_pr_k, p)
 
 
 def diffie_hellman_key_exchange(a: int, p: int, option: int | None = None) -> bool:

--- a/algorithms/math/rabin_miller.py
+++ b/algorithms/math/rabin_miller.py
@@ -14,7 +14,7 @@ Complexity:
 
 from __future__ import annotations
 
-import random
+import secrets
 
 
 def is_prime(n: int, k: int) -> bool:
@@ -34,7 +34,7 @@ def is_prime(n: int, k: int) -> bool:
         False
     """
 
-    def _pow2_factor(num: int) -> tuple[int, float]:
+    def _pow2_factor(num: int) -> tuple[int, int]:
         """Factor num into 2^power * odd_part.
 
         Args:
@@ -45,7 +45,7 @@ def is_prime(n: int, k: int) -> bool:
         """
         power = 0
         while num % 2 == 0:
-            num /= 2
+            num //= 2
             power += 1
         return power, num
 
@@ -79,6 +79,6 @@ def is_prime(n: int, k: int) -> bool:
     r, d = _pow2_factor(n - 1)
 
     return all(
-        not _valid_witness(random.randrange(2, n - 2))
+        not _valid_witness(secrets.randbelow(n - 4) + 2)
         for _ in range(k)
     )

--- a/algorithms/math/rsa.py
+++ b/algorithms/math/rsa.py
@@ -13,7 +13,21 @@ Complexity:
 
 from __future__ import annotations
 
-import random
+import secrets
+
+
+def _extended_gcd(a: int, b: int) -> tuple[int, int, int]:
+    if a == 0:
+        return b, 0, 1
+    g, x, y = _extended_gcd(b % a, a)
+    return g, y - (b // a) * x, x
+
+
+def _modinv(a: int, m: int) -> int:
+    g, x, _ = _extended_gcd(a, m)
+    if g != 1:
+        raise ValueError(f"Modular inverse does not exist: gcd({a}, {m}) = {g}")
+    return x % m
 
 
 def generate_key(k: int, seed: int | None = None) -> tuple[int, int, int]:
@@ -21,37 +35,22 @@ def generate_key(k: int, seed: int | None = None) -> tuple[int, int, int]:
 
     Args:
         k: The number of bits in the modulus n.
-        seed: Optional random seed for reproducibility.
+        seed: Optional random seed for reproducibility (ignored, kept for API compatibility).
 
     Returns:
         A tuple (n, e, d) where n is the modulus, e is the encryption
         exponent, and d is the decryption exponent.
 
     Examples:
-        >>> n, e, d = generate_key(16, seed=42)
+        >>> n, e, d = generate_key(16)
     """
-
-    def _modinv(a: int, m: int) -> int:
-        """Calculate the modular inverse of a mod m.
-
-        Args:
-            a: The integer.
-            m: The modulus.
-
-        Returns:
-            b such that (a * b) % m == 1.
-        """
-        b = 1
-        while (a * b) % m != 1:
-            b += 1
-        return b
 
     def _gen_prime(k: int, seed: int | None = None) -> int:
         """Generate a random prime with k bits.
 
         Args:
             k: The number of bits.
-            seed: Optional random seed.
+            seed: Unused, kept for API compatibility.
 
         Returns:
             A prime number.
@@ -65,13 +64,12 @@ def generate_key(k: int, seed: int | None = None) -> tuple[int, int, int]:
                 for i in range(2, int(num**0.5) + 1)
             )
 
-        random.seed(seed)
         while True:
-            key = random.randrange(int(2 ** (k - 1)), int(2**k))
+            key = secrets.randbelow(int(2**k) - int(2 ** (k - 1))) + int(2 ** (k - 1))
             if _is_prime(key):
                 return key
 
-    p_size = k / 2
+    p_size = k // 2
     q_size = k - p_size
 
     e = _gen_prime(k, seed)

--- a/algorithms/math/rsa.py
+++ b/algorithms/math/rsa.py
@@ -35,7 +35,8 @@ def generate_key(k: int, seed: int | None = None) -> tuple[int, int, int]:
 
     Args:
         k: The number of bits in the modulus n.
-        seed: Optional random seed for reproducibility (ignored, kept for API compatibility).
+        seed: Optional random seed for reproducibility
+            (ignored, kept for API compatibility).
 
     Returns:
         A tuple (n, e, d) where n is the modulus, e is the encryption

--- a/algorithms/math/rsa.py
+++ b/algorithms/math/rsa.py
@@ -17,10 +17,15 @@ import secrets
 
 
 def _extended_gcd(a: int, b: int) -> tuple[int, int, int]:
-    if a == 0:
-        return b, 0, 1
-    g, x, y = _extended_gcd(b % a, a)
-    return g, y - (b // a) * x, x
+    old_r, r = a, b
+    old_s, s = 1, 0
+    old_t, t = 0, 1
+    while r != 0:
+        q = old_r // r
+        old_r, r = r, old_r - q * r
+        old_s, s = s, old_s - q * s
+        old_t, t = t, old_t - q * t
+    return old_r, old_s, old_t
 
 
 def _modinv(a: int, m: int) -> int:


### PR DESCRIPTION
## Summary
- Remove `eval()` in `kth_to_last_eval`, replace with safe iterative loop (#2728)
- Replace `random` module with `secrets` in `rsa.py`, `diffie_hellman_key_exchange.py`, `rabin_miller.py` (#2729)
- Replace unbounded `_modinv` while-loop with extended Euclidean algorithm (#2730)
- Pin all GitHub Actions in `publish.yml` to commit SHAs (#2731)
- Fix float division `num /= 2` → `num //= 2` in `rabin_miller.py` (#2733)

## Test plan
- [x] `python -m pytest tests/test_math.py tests/test_linked_list.py -x -q` — 62 tests pass
- [x] No `eval()` remaining in codebase
- [x] No `import random` in crypto modules
- [x] All CI actions pinned to SHAs

Closes #2728, #2729, #2730, #2731, #2733

🤖 Generated with [Claude Code](https://claude.com/claude-code)