### PR TITLE
Fix BFS O(n²) regression, bellman_ford sink nodes, heap bugs

### DIFF
--- a/algorithms/data_structures/heap.py
+++ b/algorithms/data_structures/heap.py
@@ -95,7 +95,9 @@ class BinaryHeap(AbstractHeap):
                     self.heap[index // 2],
                     self.heap[index],
                 )
-            index = index // 2
+                index = index // 2
+            else:
+                break
 
     def insert(self, val: int) -> None:
         """Insert a value into the heap.
@@ -128,7 +130,7 @@ class BinaryHeap(AbstractHeap):
         Args:
             index: Index of the element to percolate down.
         """
-        while 2 * index < self.current_size:
+        while 2 * index <= self.current_size:
             smaller_child = self.min_child(index)
             if self.heap[smaller_child] < self.heap[index]:
                 self.heap[smaller_child], self.heap[index] = (

--- a/algorithms/graph/bellman_ford.py
+++ b/algorithms/graph/bellman_ford.py
@@ -69,7 +69,10 @@ def _initialize_single_source(
         distance: Dictionary to store shortest distances (modified in place).
         predecessor: Dictionary to store path predecessors (modified in place).
     """
-    for node in graph:
+    all_nodes: set[str] = set(graph.keys())
+    for neighbors in graph.values():
+        all_nodes.update(neighbors.keys())
+    for node in all_nodes:
         distance[node] = float("inf")
         predecessor[node] = None
     distance[source] = 0

--- a/algorithms/graph/check_bipartite.py
+++ b/algorithms/graph/check_bipartite.py
@@ -12,6 +12,8 @@ Complexity:
 
 from __future__ import annotations
 
+from collections import deque
+
 
 def check_bipartite(adj_list: list[list[int]]) -> bool:
     """Return True if the graph represented by *adj_list* is bipartite.
@@ -32,10 +34,10 @@ def check_bipartite(adj_list: list[list[int]]) -> bool:
     set_type = [-1 for _ in range(vertices)]
     set_type[0] = 0
 
-    queue = [0]
+    queue = deque([0])
 
     while queue:
-        current = queue.pop(0)
+        current = queue.popleft()
 
         if adj_list[current][current]:
             return False

--- a/algorithms/graph/count_islands_bfs.py
+++ b/algorithms/graph/count_islands_bfs.py
@@ -14,6 +14,8 @@ Complexity:
 
 from __future__ import annotations
 
+from collections import deque
+
 
 def count_islands(grid: list[list[int]]) -> int:
     """Return the number of islands in *grid*.
@@ -34,7 +36,7 @@ def count_islands(grid: list[list[int]]) -> int:
     num_islands = 0
     visited = [[0] * col for _ in range(row)]
     directions = [[-1, 0], [1, 0], [0, -1], [0, 1]]
-    queue: list[tuple[int, int]] = []
+    queue: deque[tuple[int, int]] = deque()
 
     for i in range(row):
         for j, num in enumerate(grid[i]):
@@ -42,7 +44,7 @@ def count_islands(grid: list[list[int]]) -> int:
                 visited[i][j] = 1
                 queue.append((i, j))
                 while queue:
-                    x, y = queue.pop(0)
+                    x, y = queue.popleft()
                     for k in range(len(directions)):
                         nx_x = x + directions[k][0]
                         nx_y = y + directions[k][1]

--- a/algorithms/graph/shortest_distance_from_all_buildings.py
+++ b/algorithms/graph/shortest_distance_from_all_buildings.py
@@ -13,6 +13,8 @@ Complexity:
 
 from __future__ import annotations
 
+from collections import deque
+
 
 def shortest_distance(grid: list[list[int]]) -> int:
     """Return the minimum total distance from an empty cell to all buildings.
@@ -64,9 +66,9 @@ def _bfs(
         j: Column of the building.
         count: Number of buildings visited so far.
     """
-    q: list[tuple[int, int, int]] = [(i, j, 0)]
+    q: deque[tuple[int, int, int]] = deque([(i, j, 0)])
     while q:
-        i, j, step = q.pop(0)
+        i, j, step = q.popleft()
         for k, col in [(i - 1, j), (i + 1, j), (i, j - 1), (i, j + 1)]:
             if (
                 0 <= k < len(grid)

--- a/algorithms/graph/traversal.py
+++ b/algorithms/graph/traversal.py
@@ -11,6 +11,7 @@ Complexity:
 
 from __future__ import annotations
 
+from collections import deque
 from typing import Any
 
 
@@ -55,9 +56,9 @@ def bfs_traverse(graph: dict[Any, list[Any]], start: Any) -> set[Any]:
         ['a', 'b']
     """
     visited: set[Any] = set()
-    queue = [start]
+    queue = deque([start])
     while queue:
-        node = queue.pop(0)
+        node = queue.popleft()
         if node not in visited:
             visited.add(node)
             for next_node in graph[node]:

--- a/algorithms/queue/zigzagiterator.py
+++ b/algorithms/queue/zigzagiterator.py
@@ -13,6 +13,8 @@ Complexity:
 
 from __future__ import annotations
 
+from collections import deque
+
 
 class ZigZagIterator:
     """Iterator that interleaves elements from two lists.
@@ -32,7 +34,7 @@ class ZigZagIterator:
             v1: First input list.
             v2: Second input list.
         """
-        self.queue: list[list[int]] = [lst for lst in (v1, v2) if lst]
+        self.queue: deque[list[int]] = deque(lst for lst in (v1, v2) if lst)
 
     def next(self) -> int:
         """Return the next element in zigzag order.
@@ -40,7 +42,7 @@ class ZigZagIterator:
         Returns:
             The next interleaved element.
         """
-        current_list = self.queue.pop(0)
+        current_list = self.queue.popleft()
         ret = current_list.pop(0)
         if current_list:
             self.queue.append(current_list)

--- a/algorithms/tree/max_height.py
+++ b/algorithms/tree/max_height.py
@@ -37,7 +37,7 @@ def max_height(root: TreeNode | None) -> int:
     queue: deque[TreeNode] = deque([root])
     while queue:
         height += 1
-        level: list[TreeNode] = []
+        level: deque[TreeNode] = deque()
         while queue:
             node = queue.popleft()
             if node.left is not None:

--- a/algorithms/tree/max_height.py
+++ b/algorithms/tree/max_height.py
@@ -13,6 +13,8 @@ Complexity:
 
 from __future__ import annotations
 
+from collections import deque
+
 from algorithms.tree.tree import TreeNode
 
 
@@ -32,12 +34,12 @@ def max_height(root: TreeNode | None) -> int:
     if root is None:
         return 0
     height = 0
-    queue: list[TreeNode] = [root]
+    queue: deque[TreeNode] = deque([root])
     while queue:
         height += 1
         level: list[TreeNode] = []
         while queue:
-            node = queue.pop(0)
+            node = queue.popleft()
             if node.left is not None:
                 level.append(node.left)
             if node.right is not None:

--- a/algorithms/tree/path_sum.py
+++ b/algorithms/tree/path_sum.py
@@ -14,6 +14,8 @@ Complexity:
 
 from __future__ import annotations
 
+from collections import deque
+
 from algorithms.tree.tree import TreeNode
 
 
@@ -83,9 +85,9 @@ def has_path_sum3(root: TreeNode | None, sum: int) -> bool:
     """
     if root is None:
         return False
-    queue: list[tuple[TreeNode, int]] = [(root, sum - root.val)]
+    queue: deque[tuple[TreeNode, int]] = deque([(root, sum - root.val)])
     while queue:
-        node, val = queue.pop(0)
+        node, val = queue.popleft()
         if node.left is None and node.right is None and val == 0:
             return True
         if node.left is not None:

--- a/algorithms/tree/path_sum2.py
+++ b/algorithms/tree/path_sum2.py
@@ -13,6 +13,8 @@ Complexity:
 
 from __future__ import annotations
 
+from collections import deque
+
 from algorithms.tree.tree import TreeNode
 
 
@@ -101,9 +103,9 @@ def path_sum3(root: TreeNode | None, sum: int) -> list[list[int]]:
     if root is None:
         return []
     result: list[list[int]] = []
-    queue: list[tuple[TreeNode, int, list[int]]] = [(root, root.val, [root.val])]
+    queue: deque[tuple[TreeNode, int, list[int]]] = deque([(root, root.val, [root.val])])
     while queue:
-        node, val, path = queue.pop(0)
+        node, val, path = queue.popleft()
         if node.left is None and node.right is None and val == sum:
             result.append(path)
         if node.left is not None:

--- a/algorithms/tree/path_sum2.py
+++ b/algorithms/tree/path_sum2.py
@@ -103,7 +103,8 @@ def path_sum3(root: TreeNode | None, sum: int) -> list[list[int]]:
     if root is None:
         return []
     result: list[list[int]] = []
-    queue: deque[tuple[TreeNode, int, list[int]]] = deque([(root, root.val, [root.val])])
+    initial = (root, root.val, [root.val])
+    queue: deque[tuple[TreeNode, int, list[int]]] = deque([initial])
     while queue:
         node, val, path = queue.popleft()
         if node.left is None and node.right is None and val == sum:


### PR DESCRIPTION
## Summary
- Replace `list.pop(0)` with `collections.deque` + `popleft()` in 8 BFS files for O(1) dequeue (#2734)
- Fix `bellman_ford` `_initialize_single_source` to include sink nodes, preventing `KeyError` (#2736)
- Fix `BinaryHeap` `perc_down` loop condition (`<` → `<=`) and add early break in `perc_up` (#2737)

## Test plan
- [x] `python -m pytest tests/test_graph.py tests/test_tree.py tests/test_queue.py tests/test_heap.py -x -q` — 59 tests pass
- [x] `grep -rn "\.pop(0)" algorithms/` returns no BFS hits
- [x] Heap handles single-child edge case correctly

Closes #2734, #2736, #2737

🤖 Generated with [Claude Code](https://claude.com/claude-code)