### PR TITLE
Structural cleanup: rewrite bst.py, fix test_insertion_sort bug

### DIFF
--- a/algorithms/data_structures/bst.py
+++ b/algorithms/data_structures/bst.py
@@ -1,148 +1,106 @@
-"""
-Implement Binary Search Tree. It has method:
-    1. Insert
-    2. Search
-    3. Size
-    4. Traversal (Preorder, Inorder, Postorder)
-"""
+"""Binary Search Tree implementation.
 
-import unittest
+A BST is a node-based binary tree where each node's left subtree contains
+only nodes with data less than the node's data, and the right subtree
+contains only nodes with data greater than the node's data.
+
+Operations and complexities (n = number of nodes):
+    - insert:    O(log n) average, O(n) worst case
+    - search:    O(log n) average, O(n) worst case
+    - size:      O(n)
+    - preorder:  O(n)
+    - inorder:   O(n)
+    - postorder: O(n)
+"""
+from __future__ import annotations
+
+from typing import Optional
 
 
 class Node:
-    def __init__(self, data):
-        self.data = data
-        self.left = None
-        self.right = None
+    def __init__(self, data: int) -> None:
+        self.data: int = data
+        self.left: Optional[Node] = None
+        self.right: Optional[Node] = None
 
 
 class BST:
-    def __init__(self):
-        self.root = None
+    def __init__(self) -> None:
+        self.root: Optional[Node] = None
 
-    def get_root(self):
+    def get_root(self) -> Optional[Node]:
         return self.root
 
-    """
-        Get the number of elements
-        Using recursion. Complexity O(logN)
-    """
+    def size(self) -> int:
+        """Return the number of nodes in the tree. Complexity: O(n)."""
+        return self._recur_size(self.root)
 
-    def size(self):
-        return self.recur_size(self.root)
-
-    def recur_size(self, root):
+    def _recur_size(self, root: Optional[Node]) -> int:
         if root is None:
             return 0
-        else:
-            return 1 + self.recur_size(root.left) + self.recur_size(root.right)
+        return 1 + self._recur_size(root.left) + self._recur_size(root.right)
 
-    """
-        Search data in bst
-        Using recursion. Complexity O(logN)
-    """
+    def search(self, data: int) -> bool:
+        """Return True if data exists in the tree. Complexity: O(log n) average."""
+        return self._recur_search(self.root, data)
 
-    def search(self, data):
-        return self.recur_search(self.root, data)
-
-    def recur_search(self, root, data):
+    def _recur_search(self, root: Optional[Node], data: int) -> bool:
         if root is None:
             return False
         if root.data == data:
             return True
-        elif data > root.data:  # Go to right root
-            return self.recur_search(root.right, data)
-        else:  # Go to left root
-            return self.recur_search(root.left, data)
+        elif data > root.data:
+            return self._recur_search(root.right, data)
+        else:
+            return self._recur_search(root.left, data)
 
-    """
-        Insert data in bst
-        Using recursion. Complexity O(logN)
-    """
-
-    def insert(self, data):
+    def insert(self, data: int) -> bool:
+        """Insert data into the tree. Return False if data already exists. Complexity: O(log n) average."""
         if self.root:
-            return self.recur_insert(self.root, data)
+            return self._recur_insert(self.root, data)
         else:
             self.root = Node(data)
             return True
 
-    def recur_insert(self, root, data):
-        if root.data == data:  # The data is already there
+    def _recur_insert(self, root: Node, data: int) -> bool:
+        if root.data == data:
             return False
-        elif data < root.data:  # Go to left root
-            if root.left:  # If left root is a node
-                return self.recur_insert(root.left, data)
-            else:  # left root is a None
+        elif data < root.data:
+            if root.left:
+                return self._recur_insert(root.left, data)
+            else:
                 root.left = Node(data)
                 return True
-        else:  # Go to right root
-            if root.right:  # If right root is a node
-                return self.recur_insert(root.right, data)
+        else:
+            if root.right:
+                return self._recur_insert(root.right, data)
             else:
                 root.right = Node(data)
                 return True
 
-    """
-        Preorder, Postorder, Inorder traversal bst
-    """
-
-    def preorder(self, root):
+    def preorder(self, root: Optional[Node]) -> list[int]:
+        """Return list of node values in preorder (root, left, right)."""
+        result: list[int] = []
         if root:
-            print(str(root.data), end=" ")
-            self.preorder(root.left)
-            self.preorder(root.right)
+            result.append(root.data)
+            result.extend(self.preorder(root.left))
+            result.extend(self.preorder(root.right))
+        return result
 
-    def inorder(self, root):
+    def inorder(self, root: Optional[Node]) -> list[int]:
+        """Return list of node values in inorder (left, root, right)."""
+        result: list[int] = []
         if root:
-            self.inorder(root.left)
-            print(str(root.data), end=" ")
-            self.inorder(root.right)
+            result.extend(self.inorder(root.left))
+            result.append(root.data)
+            result.extend(self.inorder(root.right))
+        return result
 
-    def postorder(self, root):
+    def postorder(self, root: Optional[Node]) -> list[int]:
+        """Return list of node values in postorder (left, right, root)."""
+        result: list[int] = []
         if root:
-            self.postorder(root.left)
-            self.postorder(root.right)
-            print(str(root.data), end=" ")
-
-
-"""
-    The tree is created for testing:
-
-                    10
-                 /      \
-               6         15
-              / \\       /   \
-            4     9   12      24
-                 /          /    \
-                7         20      30
-                         /
-                       18
-"""
-
-
-class TestSuite(unittest.TestCase):
-    def setUp(self):
-        self.tree = BST()
-        self.tree.insert(10)
-        self.tree.insert(15)
-        self.tree.insert(6)
-        self.tree.insert(4)
-        self.tree.insert(9)
-        self.tree.insert(12)
-        self.tree.insert(24)
-        self.tree.insert(7)
-        self.tree.insert(20)
-        self.tree.insert(30)
-        self.tree.insert(18)
-
-    def test_search(self):
-        self.assertTrue(self.tree.search(24))
-        self.assertFalse(self.tree.search(50))
-
-    def test_size(self):
-        self.assertEqual(11, self.tree.size())
-
-
-if __name__ == "__main__":
-    unittest.main()
+            result.extend(self.postorder(root.left))
+            result.extend(self.postorder(root.right))
+            result.append(root.data)
+        return result

--- a/algorithms/data_structures/bst.py
+++ b/algorithms/data_structures/bst.py
@@ -14,28 +14,26 @@ Operations and complexities (n = number of nodes):
 """
 from __future__ import annotations
 
-from typing import Optional
-
 
 class Node:
     def __init__(self, data: int) -> None:
         self.data: int = data
-        self.left: Optional[Node] = None
-        self.right: Optional[Node] = None
+        self.left: Node | None = None
+        self.right: Node | None = None
 
 
 class BST:
     def __init__(self) -> None:
-        self.root: Optional[Node] = None
+        self.root: Node | None = None
 
-    def get_root(self) -> Optional[Node]:
+    def get_root(self) -> Node | None:
         return self.root
 
     def size(self) -> int:
         """Return the number of nodes in the tree. Complexity: O(n)."""
         return self._recur_size(self.root)
 
-    def _recur_size(self, root: Optional[Node]) -> int:
+    def _recur_size(self, root: Node | None) -> int:
         if root is None:
             return 0
         return 1 + self._recur_size(root.left) + self._recur_size(root.right)
@@ -44,7 +42,7 @@ class BST:
         """Return True if data exists in the tree. Complexity: O(log n) average."""
         return self._recur_search(self.root, data)
 
-    def _recur_search(self, root: Optional[Node], data: int) -> bool:
+    def _recur_search(self, root: Node | None, data: int) -> bool:
         if root is None:
             return False
         if root.data == data:
@@ -55,7 +53,11 @@ class BST:
             return self._recur_search(root.left, data)
 
     def insert(self, data: int) -> bool:
-        """Insert data into the tree. Return False if data already exists. Complexity: O(log n) average."""
+        """Insert data into the tree.
+
+        Return False if data already exists.
+        Complexity: O(log n) average.
+        """
         if self.root:
             return self._recur_insert(self.root, data)
         else:
@@ -78,7 +80,7 @@ class BST:
                 root.right = Node(data)
                 return True
 
-    def preorder(self, root: Optional[Node]) -> list[int]:
+    def preorder(self, root: Node | None) -> list[int]:
         """Return list of node values in preorder (root, left, right)."""
         result: list[int] = []
         if root:
@@ -87,7 +89,7 @@ class BST:
             result.extend(self.preorder(root.right))
         return result
 
-    def inorder(self, root: Optional[Node]) -> list[int]:
+    def inorder(self, root: Node | None) -> list[int]:
         """Return list of node values in inorder (left, root, right)."""
         result: list[int] = []
         if root:
@@ -96,7 +98,7 @@ class BST:
             result.extend(self.inorder(root.right))
         return result
 
-    def postorder(self, root: Optional[Node]) -> list[int]:
+    def postorder(self, root: Node | None) -> list[int]:
         """Return list of node values in postorder (left, right, root)."""
         result: list[int] = []
         if root:

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -3,7 +3,6 @@ import unittest
 from algorithms.sorting import (
     bitonic_sort,
     bogo_sort,
-    insertion_sort,
     bubble_sort,
     bucket_sort,
     cocktail_shaker_sort,
@@ -12,6 +11,7 @@ from algorithms.sorting import (
     cycle_sort,
     exchange_sort,
     gnome_sort,
+    insertion_sort,
     max_heap_sort,
     merge_sort,
     min_heap_sort,

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -3,6 +3,7 @@ import unittest
 from algorithms.sorting import (
     bitonic_sort,
     bogo_sort,
+    insertion_sort,
     bubble_sort,
     bucket_sort,
     cocktail_shaker_sort,
@@ -60,7 +61,7 @@ class TestSuite(unittest.TestCase):
         self.assertTrue(is_sorted(min_heap_sort([1, 3, 2, 5, 65, 23, 57, 1232])))
 
     def test_insertion_sort(self):
-        self.assertTrue(is_sorted(bitonic_sort([1, 3, 2, 5, 65, 23, 57, 1232])))
+        self.assertTrue(is_sorted(insertion_sort([1, 3, 2, 5, 65, 23, 57, 1232])))
 
     def test_merge_sort(self):
         self.assertTrue(is_sorted(merge_sort([1, 3, 2, 5, 65, 23, 57, 1232])))


### PR DESCRIPTION
## Summary
- Rewrite `data_structures/bst.py`: add type hints, make traversals return lists instead of printing, prefix internal helpers with `_`, fix O(log n) → O(n) complexity claim, remove embedded unittest (#2726)
- Fix `test_insertion_sort` to actually test `insertion_sort` instead of `bitonic_sort` (copy-paste error) (#2735)
- Note: empty directories (`automata/`, `distribution/`, `ml/`, `unix/`) only contained `__pycache__` (gitignored), so #2724 requires no git changes

## Test plan
- [x] `python -m pytest tests/test_sorting.py -x -q` — 19 tests pass
- [x] BST traversals return lists, no `print()` calls
- [x] No embedded `unittest.TestCase` in bst.py

Closes #2726, #2735

🤖 Generated with [Claude Code](https://claude.com/claude-code)