### PR TITLE
Fix falsy-zero bug in BST validation, deduplicate TreeNode

### DIFF
--- a/algorithms/tree/bst_array_to_bst.py
+++ b/algorithms/tree/bst_array_to_bst.py
@@ -3,12 +3,7 @@ Given an array where elements are sorted in ascending order,
 convert it to a height balanced BST.
 """
 
-
-class TreeNode:
-    def __init__(self, x):
-        self.val = x
-        self.left = None
-        self.right = None
+from algorithms.common.tree_node import TreeNode
 
 
 def array_to_bst(nums):

--- a/algorithms/tree/bst_serialize_deserialize.py
+++ b/algorithms/tree/bst_serialize_deserialize.py
@@ -1,8 +1,4 @@
-class TreeNode:
-    def __init__(self, x):
-        self.val = x
-        self.left = None
-        self.right = None
+from algorithms.common.tree_node import TreeNode
 
 
 def serialize(root):

--- a/algorithms/tree/bst_validate_bst.py
+++ b/algorithms/tree/bst_validate_bst.py
@@ -12,14 +12,7 @@ tree (BST), we need to ensure that:
 """
 # ===============================================================================
 
-
-# Tree class definition
-class TreeNode:
-    def __init__(self, value):
-
-        self.val = value
-        self.left = None
-        self.right = None
+from algorithms.common.tree_node import TreeNode
 
 
 # Function to validate if a binary tree is a BST
@@ -46,24 +39,24 @@ def validate_bst(node):
     if not valid_left or not valid_right:
         return (
             False,
-            minn_left if minn_left else node.val,
-            maxx_right if maxx_right else node.val,
+            minn_left if minn_left is not None else node.val,
+            maxx_right if maxx_right is not None else node.val,
         )
 
     # Check the current node's value against the max of the left subtree
     if maxx_left is not None and maxx_left > node.val:
         return (
             False,
-            minn_left if minn_left else node.val,
-            maxx_right if maxx_right else node.val,
+            minn_left if minn_left is not None else node.val,
+            maxx_right if maxx_right is not None else node.val,
         )
 
     # Check the current node's value against the min of the right subtree
     if minn_right is not None and minn_right < node.val:
         return (
             False,
-            minn_left if minn_left else node.val,
-            maxx_right if maxx_right else node.val,
+            minn_left if minn_left is not None else node.val,
+            maxx_right if maxx_right is not None else node.val,
         )
 
     # If all checks pass, the tree/subtree is a valid BST

--- a/algorithms/tree/construct_tree_postorder_preorder.py
+++ b/algorithms/tree/construct_tree_postorder_preorder.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 from algorithms.common.tree_node import TreeNode
 
-
 pre_index = 0
 
 

--- a/algorithms/tree/construct_tree_postorder_preorder.py
+++ b/algorithms/tree/construct_tree_postorder_preorder.py
@@ -14,22 +14,7 @@ Complexity:
 
 from __future__ import annotations
 
-
-class TreeNode:
-    """A node in a binary tree.
-
-    Args:
-        val: The value stored in this node.
-        left: The left child node.
-        right: The right child node.
-    """
-
-    def __init__(
-        self, val: int, left: TreeNode | None = None, right: TreeNode | None = None
-    ) -> None:
-        self.val = val
-        self.left = left
-        self.right = right
+from algorithms.common.tree_node import TreeNode
 
 
 pre_index = 0


### PR DESCRIPTION
## Summary
- Fix `bst_validate_bst.py`: replace all truthiness checks on min/max values with explicit `is not None` checks, fixing incorrect validation for BSTs containing `0` (#2732)
- Replace local `TreeNode` class definitions with imports from `algorithms.common.tree_node` in 4 compatible files (#2725)

## Test plan
- [x] `python -m pytest tests/test_tree.py -x -q` — 11 tests pass
- [x] BST validation now correctly handles trees with node value `0`
- [x] No duplicate `class TreeNode` in changed files

Closes #2725, #2732

🤖 Generated with [Claude Code](https://claude.com/claude-code)