### PR TITLE
Fix: tighten loop bound in first_switch_pairs

### DIFF
--- a/algorithms/stack/switch_pairs.py
+++ b/algorithms/stack/switch_pairs.py
@@ -33,9 +33,7 @@ def first_switch_pairs(stack: list[int]) -> list[int]:
     storage_stack: list[int] = []
     for _ in range(len(stack)):
         storage_stack.append(stack.pop())
-    for _ in range(len(storage_stack)):
-        if len(storage_stack) == 0:
-            break
+    for _ in range((len(storage_stack)+1)//2):
         first = storage_stack.pop()
         if len(storage_stack) == 0:
             stack.append(first)


### PR DESCRIPTION
## Summary

* Tighten loop bound in `first_switch_pairs`
* Remove redundant empty-check guard made unnecessary by the fix

## Improvement

`range(len(storage_stack))` was a misleading loop bound — the loop actually
ran at most `len/2` iterations, relying on internal `break` guards to terminate
correctly. Replaced with `(len(storage_stack)+1)//2` which reflects the exact
number of iterations needed. The first empty-check guard became redundant and
was removed.

## Test plan

* `python -m pytest tests/test_stack.py` - 10 tests pass