### PR TITLE
Fix correctness issues found in repository audit

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,10 +8,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version: "3.13"
 
@@ -22,7 +22,7 @@ jobs:
         run: python -m build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5
         with:
           name: dist
           path: dist/
@@ -35,7 +35,7 @@ jobs:
       id-token: write
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6
         with:
           name: dist
           path: dist/

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -16,10 +16,10 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -9,15 +9,17 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -31,3 +33,6 @@ jobs:
 
       - name: Test with pytest
         run: python -m pytest
+
+      - name: Test documentation examples
+        run: python -m pytest --doctest-modules algorithms/

--- a/algorithms/backtracking/factor_combinations.py
+++ b/algorithms/backtracking/factor_combinations.py
@@ -25,7 +25,7 @@ def get_factors(number: int) -> list[list[int]]:
 
     Examples:
         >>> get_factors(12)
-        [[2, 6], [2, 2, 3], [3, 4]]
+        [[2, 6], [3, 4], [2, 2, 3]]
     """
     todo: list[tuple[int, int, list[int]]] = [(number, 2, [])]
     combinations: list[list[int]] = []

--- a/algorithms/backtracking/minimax.py
+++ b/algorithms/backtracking/minimax.py
@@ -25,7 +25,7 @@ def minimax(
     *depth* is the current depth (start with log2(len(scores))).
 
     >>> minimax(2, True, [3, 5, 2, 9])
-    5
+    3
     >>> minimax(3, True, [3, 5, 2, 9, 12, 5, 23, 23])
     12
     """

--- a/algorithms/backtracking/subsets.py
+++ b/algorithms/backtracking/subsets.py
@@ -24,8 +24,8 @@ def subsets(nums: list[int]) -> list[list[int]]:
         A list of all subsets.
 
     Examples:
-        >>> sorted(subsets([1, 2]), key=str)
-        [[], [1], [1, 2], [2]]
+        >>> sorted(subsets([1, 2]), key=lambda item: (len(item), item))
+        [[], [1], [2], [1, 2]]
     """
     result: list[list[int]] = []
     _backtrack(result, nums, [], 0)
@@ -61,8 +61,8 @@ def subsets_v2(nums: list[int]) -> list[list[int]]:
         A list of all subsets.
 
     Examples:
-        >>> sorted(subsets_v2([1, 2]), key=str)
-        [[], [1], [1, 2], [2]]
+        >>> sorted(subsets_v2([1, 2]), key=lambda item: (len(item), item))
+        [[], [1], [2], [1, 2]]
     """
     result: list[list[int]] = [[]]
     for number in sorted(nums):

--- a/algorithms/compression/elias.py
+++ b/algorithms/compression/elias.py
@@ -89,9 +89,9 @@ def elias_gamma(x: int) -> str:
 
     Examples:
         >>> elias_gamma(1)
-        '0'
+        '00'
         >>> elias_gamma(5)
-        '00101'
+        '11001'
     """
     return _elias_generic(_unary, x)
 
@@ -107,8 +107,8 @@ def elias_delta(x: int) -> str:
 
     Examples:
         >>> elias_delta(1)
-        '0'
+        '000'
         >>> elias_delta(5)
-        '01101'
+        '10101'
     """
     return _elias_generic(elias_gamma, x)

--- a/algorithms/compression/elias.py
+++ b/algorithms/compression/elias.py
@@ -14,6 +14,7 @@ Complexity:
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from math import log
 
 
@@ -50,48 +51,49 @@ def _unary(x: int) -> str:
         x: A positive integer.
 
     Returns:
-        A unary-coded string (x-1 ones followed by a zero).
+        A unary-coded string (x-1 zeros followed by a one).
     """
-    return (x - 1) * "1" + "0"
+    return (x - 1) * "0" + "1"
 
 
 def _elias_generic(
-    length_encoding: callable,
+    length_encoding: Callable[[int], str],
     x: int,
 ) -> str:
     """Generic Elias encoding using a pluggable length-encoding function.
 
     Args:
         length_encoding: A function to encode the length prefix.
-        x: A non-negative integer to encode.
+        x: A positive integer to encode.
 
     Returns:
         The Elias-coded bit string.
     """
-    if x == 0:
-        return "0"
+    if x <= 0:
+        raise ValueError("Elias coding is defined only for positive integers")
 
     first_part = 1 + int(_log2(x))
     remainder = x - 2 ** int(_log2(x))
     bit_count = int(_log2(x))
+    suffix = _binary(remainder, bit_count) if bit_count else ""
 
-    return length_encoding(first_part) + _binary(remainder, bit_count)
+    return length_encoding(first_part) + suffix
 
 
 def elias_gamma(x: int) -> str:
     """Encode a positive integer using Elias gamma coding.
 
     Args:
-        x: A non-negative integer.
+        x: A positive integer.
 
     Returns:
         The Elias gamma coded bit string.
 
     Examples:
         >>> elias_gamma(1)
-        '00'
+        '1'
         >>> elias_gamma(5)
-        '11001'
+        '00101'
     """
     return _elias_generic(_unary, x)
 
@@ -100,15 +102,15 @@ def elias_delta(x: int) -> str:
     """Encode a positive integer using Elias delta coding.
 
     Args:
-        x: A non-negative integer.
+        x: A positive integer.
 
     Returns:
         The Elias delta coded bit string.
 
     Examples:
         >>> elias_delta(1)
-        '000'
+        '1'
         >>> elias_delta(5)
-        '10101'
+        '01101'
     """
     return _elias_generic(elias_gamma, x)

--- a/algorithms/graph/find_all_cliques.py
+++ b/algorithms/graph/find_all_cliques.py
@@ -51,4 +51,4 @@ def find_all_cliques(edges: dict[str, set[str]]) -> list[list[str]]:
 
     possibles = set(edges.keys())
     _expand_clique(possibles, set())
-    return solutions
+    return sorted(sorted(clique) for clique in solutions)

--- a/algorithms/graph/satisfiability.py
+++ b/algorithms/graph/satisfiability.py
@@ -148,7 +148,7 @@ def solve_sat(
 
     Examples:
         >>> solve_sat([(('x', False), ('y', False)), (('x', True), ('y', True))])
-        {'x': False, 'y': False}
+        {'x': True, 'y': False}
     """
     graph = _build_graph(formula)
     vertex_scc = _scc(graph)

--- a/algorithms/graph/sudoku_solver.py
+++ b/algorithms/graph/sudoku_solver.py
@@ -55,7 +55,9 @@ class Sudoku:
                     val[(i, j)] = []
         for i, j in val:
             inval = (
-                d.get(("r", i), []) + d.get(("c", j), []) + d.get((i / 3, j / 3), [])
+                d.get(("r", i), [])
+                + d.get(("c", j), [])
+                + d.get((i // 3, j // 3), [])
             )
             val[(i, j)] = [n for n in a if n not in inval]
         return val
@@ -100,7 +102,7 @@ class Sudoku:
             if n in self.val[ind] and (
                 ind[0] == i
                 or ind[1] == j
-                or (ind[0] / 3, ind[1] / 3) == (i / 3, j / 3)
+                or (ind[0] // 3, ind[1] // 3) == (i // 3, j // 3)
             ):
                     update[ind] = n
                     self.val[ind].remove(n)

--- a/algorithms/graph/transitive_closure_dfs.py
+++ b/algorithms/graph/transitive_closure_dfs.py
@@ -48,7 +48,7 @@ class Graph:
         """
         self.closure[source][target] = 1
 
-        for adjacent in self.graph[target]:
+        for adjacent in self.graph.get(target, []):
             if self.closure[source][adjacent] == 0:
                 self._dfs_util(source, adjacent)
 

--- a/algorithms/map/longest_common_substring.py
+++ b/algorithms/map/longest_common_substring.py
@@ -29,7 +29,7 @@ def max_common_sub_string(s1: str, s2: str) -> str:
 
     Examples:
         >>> max_common_sub_string("abcdef", "acdbef")
-        'ef'
+        'cd'
     """
     char_index = {s2[i]: i for i in range(len(s2))}
     max_length = 0

--- a/algorithms/math/cosine_similarity.py
+++ b/algorithms/math/cosine_similarity.py
@@ -47,8 +47,8 @@ def cosine_similarity(vec1: list[float], vec2: list[float]) -> float:
         ValueError: If vectors have different lengths.
 
     Examples:
-        >>> cosine_similarity([1, 1, 1], [1, 2, -1])
-        0.4714045207910317
+        >>> round(cosine_similarity([1, 1, 1], [1, 2, -1]), 15)
+        0.471404520791032
     """
     if len(vec1) != len(vec2):
         raise ValueError(

--- a/algorithms/math/diffie_hellman_key_exchange.py
+++ b/algorithms/math/diffie_hellman_key_exchange.py
@@ -5,6 +5,11 @@ Implements the Diffie-Hellman key exchange protocol, which enables two parties
 to establish a shared secret over an insecure channel using discrete
 logarithm properties.
 
+Warning:
+    This implementation is for education only. It does not authenticate
+    peers, validate production-grade parameters, or derive keys from the raw
+    shared secret. Do not use it as a real key-exchange protocol.
+
 Reference: https://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange
 
 Complexity:

--- a/algorithms/math/extended_gcd.py
+++ b/algorithms/math/extended_gcd.py
@@ -28,14 +28,14 @@ def extended_gcd(num1: int, num2: int) -> tuple[int, int, int]:
         >>> extended_gcd(8, 2)
         (0, 1, 2)
         >>> extended_gcd(13, 17)
-        (0, 1, 17)
+        (4, -3, 1)
     """
     old_s, s = 1, 0
     old_t, t = 0, 1
     old_r, r = num1, num2
 
     while r != 0:
-        quotient = old_r / r
+        quotient = old_r // r
 
         old_r, r = r, old_r - quotient * r
         old_s, s = s, old_s - quotient * s

--- a/algorithms/math/extended_gcd.py
+++ b/algorithms/math/extended_gcd.py
@@ -41,4 +41,7 @@ def extended_gcd(num1: int, num2: int) -> tuple[int, int, int]:
         old_s, s = s, old_s - quotient * s
         old_t, t = t, old_t - quotient * t
 
+    if old_r < 0:
+        old_s, old_t, old_r = -old_s, -old_t, -old_r
+
     return old_s, old_t, old_r

--- a/algorithms/math/gcd.py
+++ b/algorithms/math/gcd.py
@@ -37,7 +37,7 @@ def gcd(a: int, b: int) -> int:
     b_int = isinstance(b, int)
     a = abs(a)
     b = abs(b)
-    if not (a_int or b_int):
+    if not (a_int and b_int):
         raise ValueError("Input arguments are not integers")
 
     if (a == 0) or (b == 0):
@@ -62,7 +62,7 @@ def lcm(a: int, b: int) -> int:
         >>> lcm(8, 12)
         24
     """
-    return abs(a) * abs(b) / gcd(a, b)
+    return abs(a) * abs(b) // gcd(a, b)
 
 
 def trailing_zero(x: int) -> int:

--- a/algorithms/math/next_perfect_square.py
+++ b/algorithms/math/next_perfect_square.py
@@ -14,7 +14,7 @@ Complexity:
 from __future__ import annotations
 
 
-def find_next_square(sq: float) -> float:
+def find_next_square(sq: float) -> int:
     """Find the next perfect square after sq.
 
     Args:
@@ -31,11 +31,11 @@ def find_next_square(sq: float) -> float:
     """
     root = sq**0.5
     if root.is_integer():
-        return (root + 1) ** 2
+        return int((root + 1) ** 2)
     return -1
 
 
-def find_next_square2(sq: float) -> float:
+def find_next_square2(sq: float) -> int:
     """Find the next perfect square using modulo check.
 
     Args:
@@ -51,4 +51,4 @@ def find_next_square2(sq: float) -> float:
         -1
     """
     root = sq**0.5
-    return -1 if root % 1 else (root + 1) ** 2
+    return -1 if root % 1 else int((root + 1) ** 2)

--- a/algorithms/math/nth_digit.py
+++ b/algorithms/math/nth_digit.py
@@ -35,6 +35,6 @@ def find_nth_digit(n: int) -> int:
         length += 1
         count *= 10
         start *= 10
-    start += (n - 1) / length
+    start += (n - 1) // length
     s = str(start)
     return int(s[(n - 1) % length])

--- a/algorithms/math/num_perfect_squares.py
+++ b/algorithms/math/num_perfect_squares.py
@@ -39,7 +39,7 @@ def num_perfect_squares(number: int) -> int:
         return 1
 
     while number > 0 and number % 4 == 0:
-        number /= 4
+        number //= 4
 
     if number % 8 == 7:
         return 4

--- a/algorithms/math/polynomial.py
+++ b/algorithms/math/polynomial.py
@@ -33,8 +33,8 @@ class Monomial:
             coeff: The coefficient (defaults to 0 if empty, 1 otherwise).
 
         Examples:
-            >>> Monomial({1: 1})  # (a_1)^1
-            >>> Monomial({1: 3, 2: 2}, 12)  # 12(a_1)^3(a_2)^2
+            >>> _ = Monomial({1: 1})  # (a_1)^1
+            >>> _ = Monomial({1: 3, 2: 2}, 12)  # 12(a_1)^3(a_2)^2
         """
         self.variables = dict()
 

--- a/algorithms/math/rsa.py
+++ b/algorithms/math/rsa.py
@@ -4,6 +4,11 @@ RSA Encryption Algorithm
 Implements RSA key generation, encryption, and decryption. RSA uses separate
 public and private keys where ((x^e)^d) % n == x % n.
 
+Warning:
+    This is a textbook implementation for education. It does not implement
+    secure padding, hardened prime generation, side-channel protections, or
+    safe message encoding. Do not use it to protect real data.
+
 Reference: https://en.wikipedia.org/wiki/RSA_(cryptosystem)
 
 Complexity:

--- a/algorithms/matrix/matrix_inversion.py
+++ b/algorithms/matrix/matrix_inversion.py
@@ -33,7 +33,7 @@ def invert_matrix(
 
     Examples:
         >>> invert_matrix([[1, 1], [1, 2]])
-        [[2, -1], [-1, 1]]
+        [[2.0, -1.0], [-1.0, 1.0]]
     """
     if not _array_is_matrix(matrix):
         return [[-1]]

--- a/algorithms/matrix/sum_sub_squares.py
+++ b/algorithms/matrix/sum_sub_squares.py
@@ -26,7 +26,7 @@ def sum_sub_squares(matrix: list[list[int]], k: int) -> list[list[int]] | None:
 
     Examples:
         >>> sum_sub_squares([[1, 1, 1], [2, 2, 2], [3, 3, 3]], 2)
-        [[6, 6], [9, 9]]
+        [[6, 6], [10, 10]]
     """
     size = len(matrix)
     if k > size:

--- a/algorithms/searching/search_rotate.py
+++ b/algorithms/searching/search_rotate.py
@@ -74,7 +74,7 @@ def search_rotate_recur(
         >>> search_rotate_recur([4, 5, 6, 7, 0, 1, 2], 0, 6, 0)
         4
     """
-    if low >= high:
+    if low > high:
         return -1
     mid = (low + high) // 2
     if val == array[mid]:

--- a/algorithms/stack/ordered_stack.py
+++ b/algorithms/stack/ordered_stack.py
@@ -57,7 +57,7 @@ class OrderedStack:
         if self.is_empty() or item > self.peek():
             self._push_direct(item)
         else:
-            while item < self.peek() and not self.is_empty():
+            while not self.is_empty() and item < self.peek():
                 temp_stack._push_direct(self.pop())
             self._push_direct(item)
             while not temp_stack.is_empty():

--- a/algorithms/string/text_justification.py
+++ b/algorithms/string/text_justification.py
@@ -30,7 +30,7 @@ def text_justification(words: list[str], max_width: int) -> list[str]:
 
     Examples:
         >>> text_justification(["What", "must", "be"], 16)
-        ['What   must   be']
+        ['What must be    ']
     """
     result: list[str] = []
     row_length = 0

--- a/algorithms/tree/__init__.py
+++ b/algorithms/tree/__init__.py
@@ -33,6 +33,7 @@ from algorithms.tree.path_sum import has_path_sum, has_path_sum2, has_path_sum3
 from algorithms.tree.path_sum2 import path_sum, path_sum2, path_sum3
 from algorithms.tree.pretty_print import tree_print
 from algorithms.tree.same_tree import is_same_tree
+from algorithms.tree.traversal_inorder import inorder, inorder_rec
 from algorithms.tree.tree import TreeNode
 
 __all__ = [
@@ -53,6 +54,8 @@ __all__ = [
     "is_subtree",
     "is_symmetric",
     "is_symmetric_iterative",
+    "inorder",
+    "inorder_rec",
     "lca",
     "longest_consecutive",
     "max_height",

--- a/algorithms/tree/bst_count_left_node.py
+++ b/algorithms/tree/bst_count_left_node.py
@@ -17,7 +17,7 @@ storing the values 6, 3, 7, and 10):
 
 import unittest
 
-from bst import bst
+from algorithms.data_structures.bst import BST
 
 
 def count_left_node(root):
@@ -47,7 +47,7 @@ def count_left_node(root):
 
 class TestSuite(unittest.TestCase):
     def setUp(self):
-        self.tree = bst()
+        self.tree = BST()
         self.tree.insert(9)
         self.tree.insert(6)
         self.tree.insert(12)

--- a/algorithms/tree/bst_delete_node.py
+++ b/algorithms/tree/bst_delete_node.py
@@ -65,7 +65,7 @@ class Solution:
         # If left or right child got deleted, the returned root is
         # the child of the deleted node.
         elif root.val > key:
-            root.left = self.deleteNode(root.left, key)
+            root.left = self.delete_node(root.left, key)
         else:
-            root.right = self.deleteNode(root.right, key)
+            root.right = self.delete_node(root.right, key)
         return root

--- a/algorithms/tree/bst_depth_sum.py
+++ b/algorithms/tree/bst_depth_sum.py
@@ -18,7 +18,7 @@ For example:
 
 import unittest
 
-from bst import bst
+from algorithms.data_structures.bst import BST
 
 
 def depth_sum(root, n):
@@ -57,7 +57,7 @@ def recur_depth_sum(root, n):
 
 class TestSuite(unittest.TestCase):
     def setUp(self):
-        self.tree = bst()
+        self.tree = BST()
         self.tree.insert(9)
         self.tree.insert(6)
         self.tree.insert(12)

--- a/algorithms/tree/bst_height.py
+++ b/algorithms/tree/bst_height.py
@@ -18,7 +18,7 @@ For example: height of tree is 4
 
 import unittest
 
-from bst import bst
+from algorithms.data_structures.bst import BST
 
 
 def height(root):
@@ -46,7 +46,7 @@ def height(root):
 
 class TestSuite(unittest.TestCase):
     def setUp(self):
-        self.tree = bst()
+        self.tree = BST()
         self.tree.insert(9)
         self.tree.insert(6)
         self.tree.insert(12)

--- a/algorithms/tree/bst_num_empty.py
+++ b/algorithms/tree/bst_num_empty.py
@@ -21,7 +21,7 @@ For example: the following tree has 10 empty branch (* is empty branch)
 
 import unittest
 
-from bst import bst
+from algorithms.data_structures.bst import BST
 
 
 def num_empty(root):
@@ -53,7 +53,7 @@ def num_empty(root):
 
 class TestSuite(unittest.TestCase):
     def setUp(self):
-        self.tree = bst()
+        self.tree = BST()
         self.tree.insert(9)
         self.tree.insert(6)
         self.tree.insert(12)

--- a/algorithms/tree/construct_tree_postorder_preorder.py
+++ b/algorithms/tree/construct_tree_postorder_preorder.py
@@ -43,7 +43,7 @@ def construct_tree_util(
     """
     global pre_index
 
-    if pre_index == -1:
+    if low == 0 and high == size - 1:
         pre_index = 0
 
     if pre_index >= size or low > high:

--- a/algorithms/tree/max_path_sum.py
+++ b/algorithms/tree/max_path_sum.py
@@ -30,24 +30,25 @@ def max_path_sum(root: TreeNode | None) -> float:
         >>> max_path_sum(TreeNode(1))
         1
     """
-    maximum = float("-inf")
-    _helper(root, maximum)
+    _, maximum = _helper(root)
     return maximum
 
 
-def _helper(root: TreeNode | None, maximum: float) -> float:
-    """Recursively compute the maximum single-branch sum from each node.
+def _helper(root: TreeNode | None) -> tuple[float, float]:
+    """Compute the best branch and overall path sums below ``root``.
 
     Args:
         root: The current node.
-        maximum: The running maximum path sum.
-
     Returns:
-        The maximum sum of a path extending from this node to a descendant.
+        A tuple containing the best downward branch and the best complete
+        path found in the subtree.
     """
     if root is None:
-        return 0
-    left = _helper(root.left, maximum)
-    right = _helper(root.right, maximum)
-    maximum = max(maximum, left + right + root.val)
-    return root.val + maximum
+        return 0, float("-inf")
+
+    left_branch, left_maximum = _helper(root.left)
+    right_branch, right_maximum = _helper(root.right)
+    branch = root.val + max(0, left_branch, right_branch)
+    through_root = root.val + max(0, left_branch) + max(0, right_branch)
+    maximum = max(through_root, left_maximum, right_maximum)
+    return branch, maximum

--- a/tests/test_audit_regressions.py
+++ b/tests/test_audit_regressions.py
@@ -59,7 +59,19 @@ def test_sudoku_solution_respects_rows_columns_and_subgrids() -> None:
     assert all(set(group) == expected for group in groups)
 
 
-@pytest.mark.parametrize("left,right", [(240, 46), (99, 78), (-25, 10)])
+@pytest.mark.parametrize(
+    "left,right",
+    [
+        (240, 46),
+        (99, 78),
+        (-25, 10),
+        (25, -10),
+        (-25, -10),
+        (0, -5),
+        (-5, 0),
+        (0, 0),
+    ],
+)
 def test_extended_gcd_satisfies_bezout_identity(left: int, right: int) -> None:
     s, t, result = extended_gcd(left, right)
 

--- a/tests/test_audit_regressions.py
+++ b/tests/test_audit_regressions.py
@@ -1,0 +1,122 @@
+"""Regression tests for defects found during the repository-wide audit."""
+
+from __future__ import annotations
+
+import importlib
+import math
+
+import pytest
+
+from algorithms.common import TreeNode
+from algorithms.graph.sudoku_solver import Sudoku
+from algorithms.graph.transitive_closure_dfs import Graph
+from algorithms.math.extended_gcd import extended_gcd
+from algorithms.math.gcd import gcd, lcm
+from algorithms.searching.search_rotate import search_rotate_recur
+from algorithms.stack.ordered_stack import OrderedStack
+from algorithms.tree.bst_delete_node import Solution
+from algorithms.tree.max_path_sum import max_path_sum
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "algorithms.tree.bst_count_left_node",
+        "algorithms.tree.bst_depth_sum",
+        "algorithms.tree.bst_height",
+        "algorithms.tree.bst_num_empty",
+    ],
+)
+def test_tree_modules_import(module_name: str) -> None:
+    importlib.import_module(module_name)
+
+
+def test_sudoku_solution_respects_rows_columns_and_subgrids() -> None:
+    board = [
+        list("53..7...."),
+        list("6..195..."),
+        list(".98....6."),
+        list("8...6...3"),
+        list("4..8.3..1"),
+        list("7...2...6"),
+        list(".6....28."),
+        list("...419..5"),
+        list("....8..79"),
+    ]
+
+    assert Sudoku(board, 9, 9).solve()
+
+    expected = set("123456789")
+    groups = list(board)
+    groups.extend([list(column) for column in zip(*board, strict=True)])
+    groups.extend(
+        [
+            [board[row + i][column + j] for i in range(3) for j in range(3)]
+            for row in (0, 3, 6)
+            for column in (0, 3, 6)
+        ]
+    )
+    assert all(set(group) == expected for group in groups)
+
+
+@pytest.mark.parametrize("left,right", [(240, 46), (99, 78), (-25, 10)])
+def test_extended_gcd_satisfies_bezout_identity(left: int, right: int) -> None:
+    s, t, result = extended_gcd(left, right)
+
+    assert result == math.gcd(left, right)
+    assert left * s + right * t == result
+
+
+def test_max_path_sum_handles_positive_and_negative_trees() -> None:
+    root = TreeNode(
+        -10,
+        TreeNode(9),
+        TreeNode(20, TreeNode(15), TreeNode(7)),
+    )
+
+    assert max_path_sum(root) == 42
+    assert max_path_sum(TreeNode(-3)) == -3
+
+
+def test_bst_delete_recurses_to_non_root_node() -> None:
+    root = TreeNode(5, TreeNode(3), TreeNode(6))
+
+    result = Solution().delete_node(root, 3)
+
+    assert result is root
+    assert result.left is None
+
+
+def test_recursive_rotated_search_checks_singleton_range() -> None:
+    values = [4, 5, 6, 7, 0, 1, 2]
+
+    assert search_rotate_recur(values, 0, len(values) - 1, 0) == 4
+    assert search_rotate_recur([1], 0, 0, 1) == 0
+
+
+def test_ordered_stack_can_insert_new_minimum() -> None:
+    stack = OrderedStack()
+    for value in (3, 1, 2):
+        stack.push(value)
+
+    assert [stack.pop(), stack.pop(), stack.pop()] == [3, 2, 1]
+
+
+def test_transitive_closure_handles_sink_and_isolated_vertices() -> None:
+    graph = Graph(3)
+    graph.add_edge(0, 1)
+
+    assert graph.transitive_closure() == [
+        [1, 1, 0],
+        [0, 1, 0],
+        [0, 0, 1],
+    ]
+
+
+def test_gcd_rejects_mixed_numeric_types_and_lcm_is_integer() -> None:
+    with pytest.raises(ValueError, match="not integers"):
+        gcd(3.5, 2)
+
+    result = lcm(8, 12)
+    assert result == 24
+    assert isinstance(result, int)

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -60,45 +60,43 @@ class TestRLECompression(unittest.TestCase):
 class TestEliasCoding(unittest.TestCase):
     def test_elias_gamma(self):
         correct_result = [
-            "0",
-            "00",
-            "100",
-            "101",
-            "11000",
-            "11001",
-            "11010",
-            "11011",
-            "1110000",
-            "1110001",
-            "1110010",
+            "1",
+            "010",
+            "011",
+            "00100",
+            "00101",
+            "00110",
+            "00111",
+            "0001000",
+            "0001001",
+            "0001010",
         ]
 
-        result = []
-        for i in range(11):
-            result.append(elias_gamma(i))
+        result = [elias_gamma(i) for i in range(1, 11)]
 
         self.assertEqual(correct_result, result)
+        with self.assertRaises(ValueError):
+            elias_gamma(0)
 
     def test_elias_delta(self):
         correct_result = [
-            "0",
-            "000",
-            "1000",
-            "1001",
-            "10100",
-            "10101",
-            "10110",
-            "10111",
-            "11000000",
-            "11000001",
-            "11000010",
+            "1",
+            "0100",
+            "0101",
+            "01100",
+            "01101",
+            "01110",
+            "01111",
+            "00100000",
+            "00100001",
+            "00100010",
         ]
 
-        result = []
-        for i in range(11):
-            result.append(elias_delta(i))
+        result = [elias_delta(i) for i in range(1, 11)]
 
         self.assertEqual(correct_result, result)
+        with self.assertRaises(ValueError):
+            elias_delta(0)
 
 
 if __name__ == "__main__":

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -517,7 +517,7 @@ class TestSudoku(unittest.TestCase):
         test_obj = Sudoku(board, 3, 3)
         test_obj.solve()
         self.assertEqual(
-            [["5", "3", "1"], ["6", "1", "2"], ["1", "9", "8"]], test_obj.board
+            [["5", "3", "1"], ["6", "2", "4"], ["7", "9", "8"]], test_obj.board
         )
 
 

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -135,7 +135,9 @@ class TestExtendedGcd(unittest.TestCase):
 
     def test_extended_gcd(self):
         self.assertEqual((0, 1, 2), extended_gcd(8, 2))
-        self.assertEqual((0, 1, 17), extended_gcd(13, 17))
+        s, t, result = extended_gcd(13, 17)
+        self.assertEqual(1, result)
+        self.assertEqual(result, 13 * s + 17 * t)
 
 
 class TestGcd(unittest.TestCase):


### PR DESCRIPTION
## Summary

- fix Sudoku subgrid validation, extended GCD, maximum tree path sum, recursive rotated search, BST deletion, ordered stack insertion, and transitive closure
- repair four broken tree-module imports and export inorder traversal from algorithms.tree
- correct integer math behavior and make repeated tree construction state-safe
- add focused regression coverage and synchronize all executable documentation examples
- make clique output deterministic across hash seeds
- pin CI and release actions to immutable Node 24 commits, reduce workflow permissions, enforce doctests, and add educational cryptography warnings

## Validation

- 591 tracked unit and regression tests passed locally
- 478 doctests passed locally, 1 skipped
- Ruff passed
- clean sdist and wheel build succeeded
- installed-wheel sweep imported all 403 modules with zero failures
- GitHub Actions passed on Python 3.10, 3.11, 3.12, and 3.13

## Notes

The repository-wide MyPy backlog remains separate from these runtime and release fixes; this PR does not hide it with ignores or configuration suppressions.